### PR TITLE
Fix data loading and update subtitle

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -235,7 +235,7 @@
     <div class="container">
         <header>
             <h1>📬 Post Ping</h1>
-            <div class="subtitle">✨ Your whimsical Washington Post alerts dashboard ✨</div>
+            <div class="subtitle">✨ Your delightful Washington Post alerts dashboard ✨</div>
         </header>
 
         <div class="stats">
@@ -290,7 +290,7 @@
         // Load alerts data
         async function loadAlerts() {
             try {
-                const response = await fetch('../alerts.json');
+                const response = await fetch('alerts.json');
                 const data = await response.json();
 
                 // Process alerts

--- a/site/latest.rss
+++ b/site/latest.rss
@@ -6,7 +6,7 @@
     <description>An unofficial feed created by Derek Willis.</description>
     <docs>http://www.rssboard.org/rss-specification</docs>
     <generator>python-feedgen</generator>
-    <lastBuildDate>Tue, 18 Nov 2025 03:44:29 +0000</lastBuildDate>
+    <lastBuildDate>Tue, 18 Nov 2025 03:57:55 +0000</lastBuildDate>
     <item>
       <title>Larry Summers is stepping back from public commitments over Jeffrey Epstein emails, saying he is ‘deeply ashamed’</title>
       <description>“I take full responsibility for my misguided decision to continue communicating with Mr. Epstein,” Summers said in a statement. It was unclear whether the Democratic former treasury secretary would exit a wide array of boards and think tanks or if those organizations would cut ties with him. Summers is also a former president of Harvard University, where he still holds a professorship.</description>


### PR DESCRIPTION
- Copy alerts.json to site directory for local access
- Update fetch path from '../alerts.json' to 'alerts.json' to fix data loading
- Change subtitle from 'whimsical' to 'delightful' to maintain playful tone without literal descriptor